### PR TITLE
Fix resource income displaying at game start #468

### DIFF
--- a/Lords_Frontiers/Source/Lords_Frontiers/Private/Core/GameLoopManager.cpp
+++ b/Lords_Frontiers/Source/Lords_Frontiers/Private/Core/GameLoopManager.cpp
@@ -472,6 +472,7 @@ void UGameLoopManager::EnterBuildingPhase()
 
 	if ( UEconomyComponent* ec = EconomyComponent_.Get() )
 	{
+		ec->PerformInitialScan();
 		ec->RecalculateAndBroadcastNetIncome();
 	}
 }

--- a/Lords_Frontiers/Source/Lords_Frontiers/Private/Resources/EconomyComponent.cpp
+++ b/Lords_Frontiers/Source/Lords_Frontiers/Private/Resources/EconomyComponent.cpp
@@ -19,6 +19,7 @@ void UEconomyComponent::BeginPlay()
 {
 	Super::BeginPlay();
 	FindSystems();
+	SubscribeToCardEvents();
 }
 
 void UEconomyComponent::FindSystems()


### PR DESCRIPTION
Исправлен баг

<img width="1194" height="262" alt="image" src="https://github.com/user-attachments/assets/9c3c66e2-8977-4b43-8b93-5010116e9ba4" />

