### PR TITLE
Add animations to buildings #680

### DIFF
--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Magic_House.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Magic_House.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7cda934ae18a908d2e1d4b632743de641eaf7be893be2a83c7625aab6877d61a
-size 37867
+oid sha256:ca3430bbbdf3ef2c0a2a9cdaed92baeef6d86ecd4f0240b0d97bae5d658a7af5
+size 38263

--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Magic_Tower.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Magic_Tower.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3c422204aa45476fad45037091dc4a5bc11004b8bf2def4d127ab5fe9d9584a
-size 39968
+oid sha256:97b867335d3c8b1ab4b8be4d735295ac6a4f0646f7343d41a96c0f4b71cc8dee
+size 40789

--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Magic_Tower.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Magic_Tower.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02c95320365ad0a4a48d4445425cc8bcad9029fa8c8ff8fe48821f9a055c87e4
-size 38685
+oid sha256:e3c422204aa45476fad45037091dc4a5bc11004b8bf2def4d127ab5fe9d9584a
+size 39968

--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_MainBase.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_MainBase.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:581e31aaae68e8aec7bdd511f8ed82c23efb1175c97eb0ae0c5109f1d6c70372
-size 40225
+oid sha256:3a960dbf4d61fbf7eb433888a5b1606438705ce33fd3ecd6655ecda5f7894e59
+size 40510

--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Mortira.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Mortira.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57d0b95a9df1d016140b158d0adc36e5268a5d3770a3ed2465777cb6f963b852
-size 41612
+oid sha256:4a4dec35a0d0c3f20621ab9cbbbedb65025bc20d42f5c598ee88a5dc71099a9b
+size 42294

--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Mortira.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Mortira.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c57a3fd03d60e49a7938e31b79a255ea56c4618b491044e8ec8dd36036fef0a8
-size 34884
+oid sha256:57d0b95a9df1d016140b158d0adc36e5268a5d3770a3ed2465777cb6f963b852
+size 41612

--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Rapid_Tower.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Rapid_Tower.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6b403d996ed86f795c2f5feb7e571d2ff6925fa2fcaf9dcdb68a825d414a969
-size 37859
+oid sha256:e58da7a2eff5ce8bd7bc5d0e3aec3375c88fc9a43ff134931df85f996dde3434
+size 38810

--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Rapid_Tower.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Rapid_Tower.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e58da7a2eff5ce8bd7bc5d0e3aec3375c88fc9a43ff134931df85f996dde3434
+oid sha256:5e8d7035a95829c75326eae2a17154e62916df1a31caf40ec95b6a04a3497049
 size 38810

--- a/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Sniper_Tower.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Buildings/Blueprints/BP_Sniper_Tower.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf90bb80e262a63c0de37d5fff2bb4d25dc8a8f0ad59b53a18b7a8f9dc132617
-size 37802
+oid sha256:8b1a5150d8daf87c9d9c6b2118d9f51465978eb4aed08f102b5f08019f61d8e2
+size 38991

--- a/Lords_Frontiers/Source/Lords_Frontiers/Lords_Frontiers.Build.cs
+++ b/Lords_Frontiers/Source/Lords_Frontiers/Lords_Frontiers.Build.cs
@@ -23,7 +23,8 @@ public class Lords_Frontiers : ModuleRules
 	        "JsonUtilities",
 	        "Niagara",
 	        "AIModule",
-	        "GameplayTasks"
+	        "GameplayTasks",
+	        "GeometryCache"
         });
 
         PrivateDependencyModuleNames.AddRange(new string[] { });

--- a/Lords_Frontiers/Source/Lords_Frontiers/Private/Building/Building.cpp
+++ b/Lords_Frontiers/Source/Lords_Frontiers/Private/Building/Building.cpp
@@ -10,6 +10,7 @@
 #include "Utilities/TraceChannelMappings.h"
 #include "VFX/EntityVFXConfig.h"
 
+#include "GeometryCacheComponent.h"
 #include "Components/BoxComponent.h"
 #include "Engine/World.h"
 #include "Kismet/GameplayStatics.h"
@@ -22,15 +23,20 @@ ABuilding::ABuilding()
 	CollisionComponent_->SetCollisionObjectType( ECC_Entity );
 	SetRootComponent( CollisionComponent_ );
 
-	StaticMeshComponent_ = CreateDefaultSubobject<UStaticMeshComponent>( TEXT( "StaticMesh" ) );
-	StaticMeshComponent_->SetCollisionEnabled( ECollisionEnabled::NoCollision );
-	StaticMeshComponent_->SetCollisionResponseToAllChannels( ECR_Ignore );
-	StaticMeshComponent_->SetupAttachment( RootComponent );
-
 	SkeletalMeshComponent_ = CreateDefaultSubobject<USkeletalMeshComponent>( TEXT( "SkeletalMesh" ) );
 	SkeletalMeshComponent_->SetCollisionEnabled( ECollisionEnabled::NoCollision );
 	SkeletalMeshComponent_->SetCollisionResponseToAllChannels( ECR_Ignore );
 	SkeletalMeshComponent_->SetupAttachment( RootComponent );
+
+	GeometryCacheComponent_ = CreateDefaultSubobject<UGeometryCacheComponent>( TEXT( "GeometryCache" ) );
+	GeometryCacheComponent_->SetCollisionEnabled( ECollisionEnabled::NoCollision );
+	GeometryCacheComponent_->SetCollisionResponseToAllChannels( ECR_Ignore );
+	GeometryCacheComponent_->SetupAttachment( RootComponent );
+
+	StaticMeshComponent_ = CreateDefaultSubobject<UStaticMeshComponent>( TEXT( "StaticMesh" ) );
+	StaticMeshComponent_->SetCollisionEnabled( ECollisionEnabled::NoCollision );
+	StaticMeshComponent_->SetCollisionResponseToAllChannels( ECR_Ignore );
+	StaticMeshComponent_->SetupAttachment( RootComponent );
 
 	SelectionOverlayMesh_ = CreateDefaultSubobject<UStaticMeshComponent>( TEXT( "SelectionOverlayMesh" ) );
 	SelectionOverlayMesh_->SetupAttachment( RootComponent );
@@ -288,14 +294,25 @@ void ABuilding::ActivateBuildingMesh()
 {
 	if ( SkeletalMeshComponent_->GetSkeletalMeshAsset() )
 	{
-		StaticMeshComponent_->SetVisibility( false );
 		SkeletalMeshComponent_->SetVisibility( true );
+
+		GeometryCacheComponent_->SetVisibility( false );
+		StaticMeshComponent_->SetVisibility( false );
+	}
+	else if ( GeometryCacheComponent_->GetGeometryCache() )
+	{
+		GeometryCacheComponent_->SetVisibility( true );
+
+		SkeletalMeshComponent_->SetVisibility( false );
+		StaticMeshComponent_->SetVisibility( false );
 	}
 	else
 	{
 		StaticMeshComponent_->SetStaticMesh( BuildingMesh_ );
-		SkeletalMeshComponent_->SetVisibility( false );
 		StaticMeshComponent_->SetVisibility( true );
+
+		SkeletalMeshComponent_->SetVisibility( false );
+		GeometryCacheComponent_->SetVisibility( false );
 	}
 	UpdateSelectionOverlay();
 }
@@ -306,8 +323,10 @@ void ABuilding::ActivateRuinsMesh()
 	{
 		StaticMeshComponent_->SetStaticMesh( RuinedMesh_ );
 		StaticMeshComponent_->SetRenderCustomDepth( false );
-		SkeletalMeshComponent_->SetVisibility( false );
 		StaticMeshComponent_->SetVisibility( true );
+
+		SkeletalMeshComponent_->SetVisibility( false );
+		GeometryCacheComponent_->SetVisibility( false );
 	}
 	UpdateSelectionOverlay();
 }
@@ -419,6 +438,16 @@ void ABuilding::EndPlay( const EEndPlayReason::Type endPlayReason )
 		EconomyComponent_->UnregisterBuilding( this );
 	}
 	Super::EndPlay( endPlayReason );
+}
+
+void ABuilding::PostInitProperties()
+{
+	Super::PostInitProperties();
+
+	if ( !PreviewMesh_ )
+	{
+		PreviewMesh_ = BuildingMesh_;
+	}
 }
 
 void ABuilding::RestoreFromRuins()

--- a/Lords_Frontiers/Source/Lords_Frontiers/Private/Building/Construction/BuildManager.cpp
+++ b/Lords_Frontiers/Source/Lords_Frontiers/Private/Building/Construction/BuildManager.cpp
@@ -172,7 +172,7 @@ void ABuildManager::StartPlacingBuilding( TSubclassOf<ABuilding> buildingClass )
 		const ABuilding* buildingCDO = CurrentBuildingClass_->GetDefaultObject<ABuilding>();
 		if ( buildingCDO )
 		{
-			if ( UStaticMesh* buildingMesh = buildingCDO->GetBuildingMesh() )
+			if ( UStaticMesh* buildingMesh = buildingCDO->GetPreviewMesh() )
 			{
 				PreviewActor_->SetPreviewMesh( buildingMesh );
 			}

--- a/Lords_Frontiers/Source/Lords_Frontiers/Public/Building/Building.h
+++ b/Lords_Frontiers/Source/Lords_Frontiers/Public/Building/Building.h
@@ -14,9 +14,12 @@ class UEconomyComponent;
 class UBoxComponent;
 class UNiagaraSystem;
 class UHealthBarConfigDataAsset;
+class UGeometryCacheComponent;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam( FOnBuildingDeath, ABuilding*, Building );
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams( FOnBuildingDamaged, ABuilding*, Building, int32, Damage, AActor*, Instigator );
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(
+    FOnBuildingDamaged, ABuilding*, Building, int32, Damage, AActor*, Instigator
+);
 
 UCLASS( Abstract )
 class LORDS_FRONTIERS_API ABuilding : public APawn, public IEntity, public ISelectable
@@ -55,6 +58,15 @@ public:
 	TObjectPtr<UStaticMesh> GetBuildingMesh() const
 	{
 		return BuildingMesh_;
+	}
+
+	TObjectPtr<UStaticMesh> GetPreviewMesh() const
+	{
+		if ( !PreviewMesh_ )
+		{
+			return BuildingMesh_;
+		}
+		return PreviewMesh_;
 	}
 
 	const FResourceProduction& GetMaintenanceCost() const
@@ -130,6 +142,8 @@ protected:
 	virtual void BeginPlay() override;
 	virtual void EndPlay( const EEndPlayReason::Type endPlayReason ) override;
 
+	virtual void PostInitProperties() override;
+
 	virtual UNiagaraSystem* GetHitVFX() const override;
 
 	void ResolveVFXDefaults();
@@ -163,11 +177,19 @@ protected:
 	UPROPERTY( VisibleAnywhere, BlueprintReadOnly )
 	UStaticMeshComponent* StaticMeshComponent_;
 
+	UPROPERTY( VisibleAnywhere, BlueprintReadOnly )
+	UGeometryCacheComponent* GeometryCacheComponent_;
+
 	UPROPERTY( EditAnywhere, BlueprintReadOnly, Category = "Settings|Visuals" )
 	TObjectPtr<UStaticMesh> RuinedMesh_;
 
 	UPROPERTY( EditAnywhere, BlueprintReadOnly, Category = "Settings|Visuals" )
 	TObjectPtr<UStaticMesh> BuildingMesh_;
+
+	UPROPERTY(
+	    EditAnywhere, BlueprintReadOnly, Category = "Settings|Visuals", meta = ( ToolTip = "Defaults to Building Mesh" )
+	)
+	TObjectPtr<UStaticMesh> PreviewMesh_;
 
 	UPROPERTY( EditAnywhere, BlueprintReadOnly, Category = "Settings|Visuals" )
 	TObjectPtr<UMaterialInterface> SelectionMaterial_;
@@ -234,7 +256,6 @@ protected:
 private:
 	FTimerHandle RuinTimerHandle_;
 	FTimerHandle ConstructionVFXTimerHandle_;
-
 
 	FResourceProduction OriginalMaintenanceCost_;
 


### PR DESCRIPTION
## Добавлены анимации зданиям

Возникли проблемы с тем, чтобы использовать файлы GeometryCache и при этом показывать превью, поэтому пришлось редактировать код. Сейчас все работает как надо

## Настройки

Компонентов теперь довольно много, поэтому опишу как использовать разные варианты отображения здания

<p align="center">
  <img width="467" height="301" src="https://github.com/user-attachments/assets/888c7f0f-54d5-4c8b-b390-608e281d6afd" />
</p>

Для визуала используются общие настройки блупринта и 3 компонента:

1. SkeletalMeshComponent  
2. GeometryCacheComponent  
3. StaticMeshComponent (в нем ничего задавать не надо)

Независимо от того, что используется для отображения основной постройки, меш руин и меш превью устанавливаются в общих настройках здания:

<p align="center">
  <img width="480" height="312" src="https://github.com/user-attachments/assets/554bc203-3431-44f1-8bab-a52bd30a8e3f" />
</p>

Если PreviewMesh не задан, для превью используется BuildingMesh

---

### Использование GeometryCache

1. Установить Geometry Cache в GeometryCacheComponent  
2. Убрать Skeletal Mesh Asset из SkeletalMeshComponent и Building Mesh из настроек блупринта  

---

### Использование скелета

1. Установить Skeletal Mesh Asset  
2. Установить Animation Mode в `Use Animation Asset`  
3. Задать `Anim to Play` в SkeletalMeshComponent  
4. Убрать Geometry Cache из GeometryCacheComponent и Building Mesh из настроек блупринта  