### PR TITLE
Bugfix: flying dog not attacking

### DIFF
--- a/Lords_Frontiers/Content/Game/Assets/Units/Blueprints/Fly/BP_FlyDog.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Units/Blueprints/Fly/BP_FlyDog.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1725445e8cce8b552c27b5ee638a37d0555741b579e10c6aa69b35d619125e59
-size 32047
+oid sha256:38d738097c5c588d0912edc7b3b70523826f14be713f7e0ae8cb5e6fc42f05a1
+size 30937


### PR DESCRIPTION
На юните был старый неиспользуемый компонент атаки. В используемом компоненте не был указан снаряд

Проблема решена удалением лишнего компонента и добавлением снаряда