### PR TITLE
added new rescales meshes #861

### DIFF
--- a/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBomb.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBomb.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fa2c3b785992663bb05b714dba5dbab73fc0e458dbe115940445590eee89caa
+size 333580

--- a/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBombArmature_FlyPug_Armature_FlyPug_Drop_Bomb.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBombArmature_FlyPug_Armature_FlyPug_Drop_Bomb.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ab97882bbb7aa40c11614b55c48ce30954bd0888f70449a04d09e248fbd1988
+size 223301

--- a/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBombArmature_FlyPug_Armature_FlyPug_Flight.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBombArmature_FlyPug_Armature_FlyPug_Flight.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23dcbbb5be88b6ee11d6c8a72d1f2ba19707d55afa1ede1632eb95cb831b4f8
+size 194248

--- a/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBomb_PhysicsAsset.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBomb_PhysicsAsset.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c40fa59c36e1c45c27154b0c70d7385cb56a89df3b6e9855974ee4520ae8f397
+size 10129

--- a/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBomb_Skeleton.uasset
+++ b/Lords_Frontiers/Content/Game/Assets/Units/Animations/Flying_pug/2/Flying_Pug_Flight_and_DropBomb_Skeleton.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edc52ca89f516f0c66ae1232a7389ec2c982995bf4341ceca7f2f931bcd05ce6
+size 11903


### PR DESCRIPTION
Добавлены новые анимации с измененным размером для летающего юнита
Старые анимации тоже были нормального размера, видимо проблема в BP у летающего юнита
<img width="569" height="45" alt="image" src="https://github.com/user-attachments/assets/bcd718d4-ccc3-4816-b2fb-999662be64d5" />

Путь новой папки